### PR TITLE
Warning if .nomedia exists in the root folder and aborting the scan

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="path_label">Path to check for new files:</string>
     <string name="progress_completed_label">Completed, ready to start another scan.</string>
     <string name="progress_error_bad_path_label">Scan failed: bad path specified for new file search.</string>
+    <string name="progress_error_nomedia_in_root">Attention:\nThe path contains a hidden file named \".nomedia\", which prevents the system from scanning media.\nFor a successful scan, this file must be removed.</string>
     <string name="progress_filelist_label">Preparing initial list of files...</string>
     <string name="progress_database_label">Querying database...</string>
     <string name="progress_unstarted_label">Not yet started.</string>

--- a/src/com/gmail/jerickson314/sdscanner/ScanFragment.java
+++ b/src/com/gmail/jerickson314/sdscanner/ScanFragment.java
@@ -226,11 +226,22 @@ public class ScanFragment extends Fragment {
         updateProgressText(R.string.progress_filelist_label);
         mFilesToProcess = new TreeSet<File>();
         resetDebugMessages();
+        int progMsg = -1;
         if (path.exists()) {
-            this.new PreprocessTask().execute(new ScanParameters(path, restrictDbUpdate));
+            File nomediaFile = new File(path.getPath(), ".nomedia");
+            if ( nomediaFile.exists() ) {
+                progMsg = R.string.progress_error_nomedia_in_root;
+            }
+            else {
+                this.new PreprocessTask().execute(new ScanParameters(path, restrictDbUpdate));
+            }
         }
         else {
-            updateProgressText(R.string.progress_error_bad_path_label);
+            progMsg = R.string.progress_error_bad_path_label;
+        }
+
+        if (progMsg != -1) {
+            updateProgressText(progMsg);
             updateStartButtonEnabled(true);
             signalFinished();
         }


### PR DESCRIPTION
It took quite some time to realize that SD Scanner didn't work for me just because of a .nomedia file got planted somehow into the root of the sdcard.
This pull request contains code that will look for a .nomedia in the root of the given path, and if found, will both issue a message and abort the scan (which won't yield any results anyway).

If you accept this pull request, feel free to adjust the message text, which should probably be translated to the other supported languages.

Cheers.

(*) The better solution would be to introduce the ability to remove this /sdcard/.nomedia file with a click of a button, but this will require adding the WRITE_EXTERNAL_STORAGE permission. So I leave it up to you.